### PR TITLE
removes asyncstream handler for state updates

### DIFF
--- a/Sources/AutomergeRepo/Networking/Providers/PeerToPeerProvider.swift
+++ b/Sources/AutomergeRepo/Networking/Providers/PeerToPeerProvider.swift
@@ -692,13 +692,13 @@ public actor PeerToPeerProvider: NetworkProvider {
             let peeredString = v.peered ? "true" : "false"
             let initiatedString = v.initiated ? "true" : "false"
             let peerString = v.peerId ?? "nil"
-            let connectionState = await v.connection.currentConnectionState
+//            let connectionState = await v.connection.currentConnectionState
 
             Logger.peerProtocol.debug("\(k.debugDescription)")
             Logger.peerProtocol.debug(" :: peerId: \(peerString)")
             Logger.peerProtocol.debug(" :: initiated: \(initiatedString)")
             Logger.peerProtocol.debug(" :: peered: \(peeredString)")
-            Logger.peerProtocol.debug(" :: state: \(String(describing: connectionState))]")
+//            Logger.peerProtocol.debug(" :: state: \(String(describing: connectionState))]")
             Logger.peerProtocol.debug("----------------------------------------------------------")
         }
 


### PR DESCRIPTION
It may be that actor is VERY MUCH the wrong mechanism for encapsulating a connection, but the "listener not becoming ready" may well be related to not having an explicit handler in place to capture and track when it does...

This _does_ assume that I can schedule a Receive() callback before things are ready - I hope that's the case. We'll see.