### PR TITLE
removing all the actors …

### DIFF
--- a/Sources/AutomergeRepo/AutomergeRepo.swift
+++ b/Sources/AutomergeRepo/AutomergeRepo.swift
@@ -1,0 +1,6 @@
+
+@globalActor public actor AutomergeRepo {
+    public static let shared = AutomergeRepo()
+    
+    private init() {}
+}

--- a/Sources/AutomergeRepo/InternalDocHandle.swift
+++ b/Sources/AutomergeRepo/InternalDocHandle.swift
@@ -2,6 +2,7 @@ import struct Automerge.ChangeHash
 import class Automerge.Document
 import struct Automerge.SyncState
 import struct Foundation.Data
+import OSLog
 
 final class InternalDocHandle {
     enum DocHandleState {
@@ -37,7 +38,14 @@ final class InternalDocHandle {
 
     let id: DocumentId
     var doc: Automerge.Document?
-    var state: DocHandleState
+    var state: DocHandleState {
+        willSet {
+            if newValue == .unavailable {
+                print("X")
+            }
+            Logger.repo.trace("updating state of \(self.id) to \(String(describing: newValue))")
+        }
+    }
     var remoteHeads: [STORAGE_ID: Set<Automerge.ChangeHash>]
     var syncStates: [PEER_ID: SyncState]
 

--- a/Sources/AutomergeRepo/InternalDocHandle.swift
+++ b/Sources/AutomergeRepo/InternalDocHandle.swift
@@ -2,7 +2,6 @@ import struct Automerge.ChangeHash
 import class Automerge.Document
 import struct Automerge.SyncState
 import struct Foundation.Data
-import OSLog
 
 final class InternalDocHandle {
     enum DocHandleState {
@@ -38,14 +37,14 @@ final class InternalDocHandle {
 
     let id: DocumentId
     var doc: Automerge.Document?
-    var state: DocHandleState {
-        willSet {
-            if newValue == .unavailable {
-                print("X")
-            }
-            Logger.repo.trace("updating state of \(self.id) to \(String(describing: newValue))")
-        }
-    }
+    var state: DocHandleState
+// Uncomment for a trace/debugging point to see what's updating the state of a DocHandle, useful for setting
+// and capturing with a breakpoint...
+//    {
+//        willSet {
+//            Logger.repo.trace("updating state of \(self.id) to \(String(describing: newValue))")
+//        }
+//    }
     var remoteHeads: [STORAGE_ID: Set<Automerge.ChangeHash>]
     var syncStates: [PEER_ID: SyncState]
 

--- a/Sources/AutomergeRepo/Networking/NetworkProvider.swift
+++ b/Sources/AutomergeRepo/Networking/NetworkProvider.swift
@@ -39,12 +39,13 @@ import Automerge
 /// return an ``SyncV1/error(_:)`` message, close the connection, and emit ``NetworkAdapterEvents/close``.
 /// - When any other message is received, it is emitted with ``NetworkAdapterEvents/message(payload:)``.
 /// - When the transport receives a `leave` message, close the connection and emit ``NetworkAdapterEvents/close``.
+@AutomergeRepo
 public protocol NetworkProvider: Sendable {
     /// A list of all active, peered connections that the provider is maintaining.
     ///
     /// For an outgoing connection, this is typically a single connection.
     /// For a listening connection, this could be quite a few.
-    var peeredConnections: [PeerConnectionInfo] { get async }
+    var peeredConnections: [PeerConnectionInfo] { get }
 
     /// For outgoing connections, the type that represents the endpoint to connect
     /// For example, it could be `URL`, `NWEndpoint` for a Bonjour network, or a custom type.

--- a/Sources/AutomergeRepo/Networking/Providers/PeerToPeerConnection.swift
+++ b/Sources/AutomergeRepo/Networking/Providers/PeerToPeerConnection.swift
@@ -23,7 +23,8 @@ import OSLog
 /// As soon as it is established, it attempts to commence a sync operation (send and expect to receive sync messages).
 /// In addition, it includes an optional `trigger` in its initializer that, when it receives any signal value, kicks off
 /// another attempt to sync the relevant Automerge document.
-public actor PeerToPeerConnection {
+@AutomergeRepo
+public final class PeerToPeerConnection {
     // A Sendable wrapper around NWConnection to hold async handlers and relevant state
     // for the connection
 
@@ -34,6 +35,10 @@ public actor PeerToPeerConnection {
     nonisolated let readyCheckDelay: ContinuousClock.Instant.Duration
     nonisolated let defaultReceiveTimeout: ContinuousClock.Instant.Duration
     nonisolated let initiated: Bool
+
+    var peered: Bool // has the connection advanced to being peered and ready to go
+    var peerId: PEER_ID? // if peered, should be non-nil
+    var peerMetadata: PeerMetadata?
 
     let connectionQueue = DispatchQueue(label: "p2pconnection", qos: .default, attributes: .concurrent)
     nonisolated let connection: NWConnection
@@ -58,6 +63,7 @@ public actor PeerToPeerConnection {
         readyTimeout: ContinuousClock.Instant.Duration = .seconds(5),
         readyCheckDelay: ContinuousClock.Instant.Duration = .milliseconds(50)
     ) async {
+        peered = false
         self.readyTimeout = readyTimeout
         self.defaultReceiveTimeout = receiveTimeout
         self.readyCheckDelay = readyCheckDelay
@@ -77,6 +83,7 @@ public actor PeerToPeerConnection {
                 " - Initial state: \(String(describing: connection.state)) on path: \(String(describing: connection.currentPath))"
             )
 
+        
         startConnection()
     }
 
@@ -92,6 +99,7 @@ public actor PeerToPeerConnection {
         readyTimeout: ContinuousClock.Instant.Duration = .seconds(5),
         readyCheckDelay: ContinuousClock.Instant.Duration = .milliseconds(50)
     ) {
+        peered = false
         self.readyTimeout = readyTimeout
         self.defaultReceiveTimeout = receiveTimeout
         self.readyCheckDelay = readyCheckDelay

--- a/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
+++ b/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
@@ -1,6 +1,7 @@
 import OSLog
 
-public actor WebSocketProvider: NetworkProvider {
+@AutomergeRepo
+public final class WebSocketProvider: NetworkProvider {
     public typealias ProviderConfiguration = WebSocketProviderConfiguration
     public struct WebSocketProviderConfiguration: Sendable {
         let reconnectOnError: Bool

--- a/Sources/AutomergeRepo/Repo.swift
+++ b/Sources/AutomergeRepo/Repo.swift
@@ -189,8 +189,10 @@ public final class Repo {
                 .warning("Invalid documentId \(msg.documentId) received in a sync message \(msg.debugDescription)")
             return
         }
+        Logger.repo.trace(" - Sync request received for document \(docId)")
         do {
             if handles[docId] == nil {
+                Logger.repo.trace(" - No recorded handle for \(docId), creating one")
                 // There is no in-memory handle for the document being synced, so this is a request
                 // to create a local copy of the document encapsulated in the sync message.
                 let newDocument = Document()
@@ -202,6 +204,7 @@ public final class Repo {
                 _ = try await resolveDocHandle(id: docId)
             }
             guard let handle = handles[docId] else { fatalError("HANDLE DOESN'T EXIST") }
+            Logger.repo.trace(" - working on handle for \(docId), state: \(String(describing: handle.state))")
             let docFromHandle = handle.doc ?? Document()
             let syncState = syncState(id: docId, peer: msg.senderId)
             // Apply the request message as a sync update
@@ -447,11 +450,16 @@ public final class Repo {
         guard let handle = handles[id] else {
             fatalError("No stored document handle for document id: \(id)")
         }
+        Logger.repo.trace("Updated contents of document \(id), state: \(String(describing: handle.state))")
         if handle.state == .requesting {
             handle.state = .ready
         }
-        assert(handle.state == .ready)
+        // Automerge-repo https://github.com/automerge/automerge-repo/issues/343 is sending two responses,
+        // the first being UNAVAILABLE, which we use to change the state, but that triggers this unexpected
+        // assertion, we we later receive the SYNC update to set the document as expected
+        assert(handle.state == .ready || handle.state == .unavailable)
         handle.doc = doc
+        handle.state = .ready
         if let storage {
             do {
                 try await withThrowingTaskGroup(of: Void.self) { group in
@@ -515,18 +523,22 @@ public final class Repo {
 
     private func resolveDocHandle(id: DocumentId) async throws -> DocHandle {
         if let handle: InternalDocHandle = handles[id] {
+            Logger.repo.trace("RESOLVE document id \(id) [\(String(describing: handle.state))]")
             switch handle.state {
             case .idle:
                 if handle.doc != nil {
                     // if there's an Automerge document in memory, jump to ready
                     handle.state = .ready
+                    Logger.repo.trace("RESOLVE: :: \(id) -> [\(String(describing: handle.state))]")
                     // STRUCT ONLY handles[id] = handle
                 } else {
                     // otherwise, first attempt to load it from persistent storage
                     // (if available)
                     handle.state = .loading
+                    Logger.repo.trace("RESOLVE: :: \(id) -> [\(String(describing: handle.state))]")
                     // STRUCT ONLY handles[id] = handle
                 }
+                Logger.repo.trace("RESOLVE: :: continuing to resolve")
                 return try await resolveDocHandle(id: id)
             case .loading:
                 // Do we have the document
@@ -553,6 +565,7 @@ public final class Repo {
                     // peers there's a new document before jumping to the 'ready' state
                     handle.state = .ready
                     // STRUCT ONLY handles[id] = handle
+                    Logger.repo.trace("RESOLVE: :: \(id) -> [\(String(describing: handle.state))]")
                     return DocHandle(id: id, doc: docFromHandle)
                 } else {
                     // We don't have the underlying Automerge document, so attempt
@@ -562,44 +575,59 @@ public final class Repo {
                     if let doc = try await loadFromStorage(id: id) {
                         handle.state = .ready
                         // STRUCT ONLY handles[id] = handle
+                        Logger.repo.trace("RESOLVED! :: \(id) -> [\(String(describing: handle.state))]")
                         return DocHandle(id: id, doc: doc)
                     } else {
                         handle.state = .requesting
                         // STRUCT ONLY handles[id] = handle
                         pendingRequestReadAttempts[id] = 0
+                        Logger.repo.trace("RESOLVE: :: \(id) -> [\(String(describing: handle.state))]")
+                        Logger.repo.trace("RESOLVE: :: starting remote fetch")
                         try await network.startRemoteFetch(id: handle.id)
+                        Logger.repo.trace("RESOLVE: :: continuing to resolve")
                         return try await resolveDocHandle(id: id)
                     }
                 }
             case .requesting:
                 guard let updatedHandle = handles[id] else {
+                    Logger.repo.trace("RESOLVED - X :: Missing \(id) -> [UNAVAILABLE]")
                     throw Errors.DocUnavailable(id: handle.id)
                 }
                 if let doc = updatedHandle.doc, updatedHandle.state == .ready {
+                    Logger.repo.trace("RESOLVED! :: \(id) -> [\(String(describing: handle.state))]")
                     return DocHandle(id: id, doc: doc)
                 } else {
                     guard let previousRequests = pendingRequestReadAttempts[id] else {
+                        Logger.repo.trace("RESOLVED - X :: Missing \(id) from pending request read attempts -> [UNAVAILABLE]")
                         throw Errors.DocUnavailable(id: id)
                     }
                     if previousRequests < maxRetriesForFetch {
                         // we are racing against the receipt of a network result
                         // to see what we get at the end
+                        Logger.repo.trace(" :: \(id) -> [\(String(describing: handle.state))]")
+                        Logger.repo.trace(" :: check # \(previousRequests) (of \(self.maxRetriesForFetch), waiting \(self.pendingRequestWaitDuration) seconds for remote fetch")
                         try await Task.sleep(for: pendingRequestWaitDuration)
+                        Logger.repo.trace("RESOLVE: :: continuing to resolve")
                         return try await resolveDocHandle(id: id)
                     } else {
+                        Logger.repo.trace("RESOLVED - X :: failed waiting \(previousRequests) of \(self.maxRetriesForFetch) requests for  \(id) -> [UNAVAILABLE]")
                         throw Errors.DocUnavailable(id: id)
                     }
                 }
             case .ready:
                 guard let doc = handle.doc else { fatalError("DocHandle state is ready, but ._doc is null") }
+                Logger.repo.trace("RESOLVED! :: \(id) [\(String(describing: handle.state))]")
                 return DocHandle(id: id, doc: doc)
             case .unavailable:
+                Logger.repo.trace("RESOLVED - X :: \(id) -> [MARKED UNAVAILABLE]")
                 throw Errors.DocUnavailable(id: handle.id)
             case .deleted:
+                Logger.repo.trace("RESOLVED - X :: \(id) -> [MARKED DELETED]")
                 throw Errors.DocDeleted(id: handle.id)
             }
         } else {
             throw Errors.DocUnavailable(id: id)
+            Logger.repo.error("RESOLVED - X :: Error Resolving document: Repo doesn't have a handle for \(id).")
         }
     }
 }

--- a/Sources/AutomergeRepo/Storage/DocumentStorage.swift
+++ b/Sources/AutomergeRepo/Storage/DocumentStorage.swift
@@ -6,7 +6,8 @@ import OSLog
 // https://github.com/automerge/automerge-repo/blob/main/packages/automerge-repo/src/storage/StorageSubsystem.ts
 
 /// A type that provides coordinated, concurrency safe access to persist Automerge documents.
-public actor DocumentStorage {
+@AutomergeRepo
+public final class DocumentStorage {
     let chunkNamespace = "incrChanges"
     var compacting: Bool
     let _storage: any StorageProvider
@@ -20,7 +21,7 @@ public actor DocumentStorage {
 
     /// Creates a new concurrency safe document storage instance to manage changes to Automerge documents.
     /// - Parameter storage: The storage provider
-    public init(_ storage: some StorageProvider) {
+    public nonisolated init(_ storage: some StorageProvider) {
         compacting = false
         _storage = storage
         latestHeads = [:]

--- a/Sources/AutomergeRepo/Storage/StorageProvider.swift
+++ b/Sources/AutomergeRepo/Storage/StorageProvider.swift
@@ -3,6 +3,7 @@ import struct Foundation.Data
 // loose adaptation from automerge-repo storage interface
 // https://github.com/automerge/automerge-repo/blob/main/packages/automerge-repo/src/storage/StorageAdapter.ts
 /// A type that provides a an interface for persisting the changes of Automerge documents by Id
+@AutomergeRepo
 public protocol StorageProvider: Sendable {
     var id: STORAGE_ID { get }
 

--- a/Tests/AutomergeRepoTests/TestNetworkProviders/InMemoryNetwork.swift
+++ b/Tests/AutomergeRepoTests/TestNetworkProviders/InMemoryNetwork.swift
@@ -62,7 +62,7 @@ public struct InMemoryNetworkMsg: Sendable, CustomDebugStringConvertible {
     }
 }
 
-@InMemoryNetwork
+@AutomergeRepo
 public final class InMemoryNetworkConnection {
     public var description: String {
         get async {
@@ -130,7 +130,7 @@ public final class InMemoryNetworkConnection {
     }
 }
 
-@InMemoryNetwork // isolate all calls to this class using the InMemoryNetwork global actor
+@AutomergeRepo // isolate all calls to this class using the InMemoryNetwork global actor
 public final class InMemoryNetworkEndpoint: NetworkProvider {
     public typealias ProviderConfiguration = BasicNetworkConfiguration
     public typealias NetworkConnectionEndpoint = String
@@ -394,7 +394,7 @@ public final class InMemoryNetworkEndpoint: NetworkProvider {
     public func setDelegate(
         _ delegate: any NetworkEventReceiver,
         as peer: PEER_ID,
-        with metadata: AutomergeRepo.PeerMetadata?
+        with metadata: PeerMetadata?
     ) async {
         peerId = peer
         peerMetadata = metadata

--- a/Tests/AutomergeRepoTests/TestNetworkProviders/TestOutgoingNetworkProvider.swift
+++ b/Tests/AutomergeRepoTests/TestNetworkProviders/TestOutgoingNetworkProvider.swift
@@ -75,7 +75,8 @@ public struct TestOutgoingNetworkConfiguration: Sendable, CustomDebugStringConve
 /// A Test network that operates in memory
 ///
 /// Acts akin to an outbound connection - doesn't "connect" and trigger messages until you explicitly ask
-public actor TestOutgoingNetworkProvider: NetworkProvider {
+@AutomergeRepo
+public final class TestOutgoingNetworkProvider: NetworkProvider {
     public var peeredConnections: [PeerConnectionInfo] = []
 
     public typealias NetworkConnectionEndpoint = String
@@ -174,9 +175,9 @@ public actor TestOutgoingNetworkProvider: NetworkProvider {
     }
 
     public func setDelegate(
-        _ delegate: any AutomergeRepo.NetworkEventReceiver,
-        as _: AutomergeRepo.PEER_ID,
-        with _: AutomergeRepo.PeerMetadata?
+        _ delegate: any NetworkEventReceiver,
+        as _: PEER_ID,
+        with _: PeerMetadata?
     ) async {
         self.delegate = delegate
     }

--- a/Tests/AutomergeRepoTests/TestStorageProviders/InMemoryStorage.swift
+++ b/Tests/AutomergeRepoTests/TestStorageProviders/InMemoryStorage.swift
@@ -2,12 +2,8 @@ import AutomergeRepo
 import struct Foundation.Data
 import struct Foundation.UUID
 
-@globalActor public actor TestActor {
-    public static var shared = TestActor()
-}
-
 /// An in-memory only storage provider.
-@TestActor
+@AutomergeRepo
 public final class InMemoryStorage: StorageProvider {
     public nonisolated let id: STORAGE_ID = UUID().uuidString
 


### PR DESCRIPTION
- pinning all the relevant classes to a single, library-provided global actor
- removes a number of suspension class and async functions that can shift back to sync
- used nonisolated on the inits to make those explicitly non-isolated so they can be created anywhere (more easily) - didn't want to mandate async init's for these classes.