### PR TITLE
run through and make the log output more consistent for each component

### DIFF
--- a/Sources/AutomergeRepo/Networking/NetworkSubsystem.swift
+++ b/Sources/AutomergeRepo/Networking/NetworkSubsystem.swift
@@ -56,13 +56,13 @@ final class NetworkSubsystem {
             // invariant that there should be a valid doc handle available from the repo
             throw Errors.Unavailable(id: id)
         }
-        Logger.network.trace("REPONET - Initiating remote fetch for \(id)")
+        Logger.network.trace("REPONET: Initiating remote fetch for \(id)")
         let newDocument = Document()
         for adapter in adapters {
             for peerConnection in adapter.peeredConnections {
                 Logger.network
                     .trace(
-                        "REPONET - requesting \(id) from peer \(peerConnection.peerId) at \(peerConnection.endpoint)"
+                        "REPONET: requesting \(id) from peer \(peerConnection.peerId) at \(peerConnection.endpoint)"
                     )
                 // upsert the requested document into the list by peer
                 if var existingList = requestedDocuments[id] {
@@ -84,7 +84,7 @@ final class NetworkSubsystem {
                 }
             }
         }
-        Logger.network.trace("REPONET - remote fetch for \(id) finished")
+        Logger.network.trace("REPONET: remote fetch for \(id) finished")
     }
 
     func send(message: SyncV1Msg, to: PEER_ID?) async {
@@ -126,7 +126,7 @@ extension NetworkSubsystem: NetworkEventReceiver {
                 // ERROR FOR THESE MSG TYPES - expected to be handled at adapter
                 Logger.network
                     .error(
-                        "Unexpected message type received by network subsystem: \(payload.debugDescription, privacy: .public)"
+                        "REPONET: Unexpected message type received by network subsystem: \(payload.debugDescription, privacy: .public)"
                     )
                 #if DEBUG
                 fatalError("UNEXPECTED MSG")
@@ -148,7 +148,7 @@ extension NetworkSubsystem: NetworkEventReceiver {
                         )
                     return
                 }
-                Logger.network.trace("Received \(event.debugDescription) event")
+                Logger.network.trace("REPONET: Received \(event.debugDescription) event")
                 if let peersRequested = requestedDocuments[docId] {
                     Logger.network.trace("REPONET: We've requested \(docId) from \(peersRequested.count) peers:")
                     for p in peersRequested {

--- a/Sources/AutomergeRepo/Storage/DocumentStorage.swift
+++ b/Sources/AutomergeRepo/Storage/DocumentStorage.swift
@@ -1,6 +1,5 @@
 import Automerge
 import Foundation
-import OSLog
 
 // inspired from automerge-repo:
 // https://github.com/automerge/automerge-repo/blob/main/packages/automerge-repo/src/storage/StorageSubsystem.ts

--- a/Sources/AutomergeRepo/Sync/SyncV1Msg+encode+decode.swift
+++ b/Sources/AutomergeRepo/Sync/SyncV1Msg+encode+decode.swift
@@ -48,7 +48,7 @@ public extension SyncV1Msg {
         do {
             cborMsg = try CBORSerialization.cbor(from: data)
         } catch {
-            Logger.webSocket.warning("Unable to CBOR decode incoming data: \(data)")
+            Logger.coder.warning("CBOR: Unable to CBOR decode incoming data: \(data)")
             return .unknown(data)
         }
         // read the "type" of the message in order to choose the appropriate decoding path
@@ -106,7 +106,7 @@ public extension SyncV1Msg {
         do {
             return try CBORCoder.decoder.decode(SyncMsg.self, from: data)
         } catch {
-            Logger.webSocket.warning("Failed to decode data as SyncMsg")
+            Logger.coder.warning("CBOR: Failed to decode data as SyncMsg")
         }
         return nil
     }
@@ -115,7 +115,7 @@ public extension SyncV1Msg {
         do {
             return try CBORCoder.decoder.decode(RequestMsg.self, from: data)
         } catch {
-            Logger.webSocket.warning("Failed to decode data as RequestMsg")
+            Logger.coder.warning("CBOR: Failed to decode data as RequestMsg")
         }
         return nil
     }
@@ -124,7 +124,7 @@ public extension SyncV1Msg {
         do {
             return try CBORCoder.decoder.decode(UnavailableMsg.self, from: data)
         } catch {
-            Logger.webSocket.warning("Failed to decode data as UnavailableMsg")
+            Logger.coder.warning("CBOR: Failed to decode data as UnavailableMsg")
         }
         return nil
     }
@@ -135,7 +135,7 @@ public extension SyncV1Msg {
         do {
             return try CBORCoder.decoder.decode(PeerMsg.self, from: data)
         } catch {
-            Logger.webSocket.warning("Failed to decode data as PeerMsg")
+            Logger.coder.warning("CBOR: Failed to decode data as PeerMsg")
         }
         return nil
     }
@@ -144,7 +144,7 @@ public extension SyncV1Msg {
         do {
             return try CBORCoder.decoder.decode(JoinMsg.self, from: data)
         } catch {
-            Logger.webSocket.warning("Failed to decode data as JoinMsg")
+            Logger.coder.warning("CBOR: Failed to decode data as JoinMsg")
         }
         return nil
     }
@@ -153,7 +153,7 @@ public extension SyncV1Msg {
         do {
             return try CBORCoder.decoder.decode(LeaveMsg.self, from: data)
         } catch {
-            Logger.webSocket.warning("Failed to decode data as LeaveMsg")
+            Logger.coder.warning("CBOR: Failed to decode data as LeaveMsg")
         }
         return nil
     }
@@ -164,7 +164,7 @@ public extension SyncV1Msg {
         do {
             return try CBORCoder.decoder.decode(ErrorMsg.self, from: data)
         } catch {
-            Logger.webSocket.warning("Failed to decode data as ErrorMsg")
+            Logger.coder.warning("CBOR: Failed to decode data as ErrorMsg")
         }
         return nil
     }
@@ -175,7 +175,7 @@ public extension SyncV1Msg {
         do {
             return try CBORCoder.decoder.decode(EphemeralMsg.self, from: data)
         } catch {
-            Logger.webSocket.warning("Failed to decode data as EphemeralMsg")
+            Logger.coder.warning("CBOR: Failed to decode data as EphemeralMsg")
         }
         return nil
     }
@@ -186,7 +186,7 @@ public extension SyncV1Msg {
         do {
             return try CBORCoder.decoder.decode(RemoteHeadsChangedMsg.self, from: data)
         } catch {
-            Logger.webSocket.warning("Failed to decode data as RemoteHeadsChangedMsg")
+            Logger.coder.warning("CBOR: Failed to decode data as RemoteHeadsChangedMsg")
         }
         return nil
     }
@@ -195,7 +195,7 @@ public extension SyncV1Msg {
         do {
             return try CBORCoder.decoder.decode(RemoteSubscriptionChangeMsg.self, from: data)
         } catch {
-            Logger.webSocket.warning("Failed to decode data as RemoteSubscriptionChangeMsg")
+            Logger.coder.warning("CBOR: Failed to decode data as RemoteSubscriptionChangeMsg")
         }
         return nil
     }

--- a/Sources/AutomergeRepo/Sync/SyncV1Msg.swift
+++ b/Sources/AutomergeRepo/Sync/SyncV1Msg.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import OSLog
 import PotentCBOR
 
 // Automerge Repo WebSocket sync details:

--- a/Sources/AutomergeRepo/extensions/OSLog+extensions.swift
+++ b/Sources/AutomergeRepo/extensions/OSLog+extensions.swift
@@ -20,6 +20,9 @@ extension Logger {
     /// Logs updates and interaction related to the process of synchronization over the network.
     static let peerConnection = Logger(subsystem: subsystem, category: "SyncConnection")
 
+    /// Logs updates and interations performed by the sync protocol encoder and decoder.
+    static let coder = Logger(subsystem: subsystem, category: "SyncCoderDecoder")
+    
     /// Logs updates and interaction related to the process of synchronization over the network.
     static let webSocket = Logger(subsystem: subsystem, category: "WebSocket")
 


### PR DESCRIPTION
Logging is still verbose, but this goes back through all the various seperate objects that log and makes the output from them more consistent, so logs should be easier to read than the ad-hoc organic growth while debugging that happened earlier.