### PR TITLE
adding more tracing detail on failure condition

### DIFF
--- a/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
+++ b/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
@@ -68,9 +68,16 @@ public final class WebSocketProvider: NetworkProvider {
             throw Errors.NetworkProviderError(msg: "Attempting to connect before connected to a delegate")
         }
 
-        if let websocket = try await attemptConnect(to: url) {
+        if try await attemptConnect(to: url) {
+            if config.logLevel.canTrace() {
+                Logger.websocket.trace("WEBSOCKET: connected to \(url)")
+            }
             endpoint = url
-            webSocketTask = websocket
+        } else {
+            if config.logLevel.canTrace() {
+                Logger.websocket.trace("WEBSOCKET: failed to connect to \(url)")
+            }
+            return
         }
 
         assert(peered == true)
@@ -196,7 +203,7 @@ public final class WebSocketProvider: NetworkProvider {
     // Returns a new websocketTask to track (at which point, save the url as the endpoint)
     // OR throws an error (log the error, but can retry)
     // OR returns nil if we don't have the pieces needed to reconnect (cease further attempts)
-    func attemptConnect(to url: URL?) async throws -> URLSessionWebSocketTask? {
+    func attemptConnect(to url: URL?) async throws -> Bool {
         precondition(peered == false)
         guard let url,
               let peerId,
@@ -208,7 +215,7 @@ public final class WebSocketProvider: NetworkProvider {
                 Logger.websocket.trace("PeerID: \(String(describing: self.peerId))")
                 Logger.websocket.trace("Delegate: \(String(describing: self.delegate))")
             }
-            return nil
+            return false
         }
 
         // establish the WebSocket connection
@@ -251,6 +258,11 @@ public final class WebSocketProvider: NetworkProvider {
                 peered: peered
             )
             peeredConnections = [peerConnectionDetails]
+            // these need to be set _before_ we send the delegate message that we're
+            // peered, because that process in turn (can trigger/triggers) a sync
+            endpoint = url
+            self.webSocketTask = webSocketTask
+
             await delegate.receiveEvent(event: .ready(payload: peerConnectionDetails))
             if config.logLevel.canTrace() {
                 Logger.websocket.trace("WEBSOCKET: Peered to targetId: \(peerMsg.senderId) \(peerMsg.debugDescription)")
@@ -269,7 +281,7 @@ public final class WebSocketProvider: NetworkProvider {
             throw error
         }
 
-        return webSocketTask
+        return true
     }
 
     // throw error on timeout
@@ -358,9 +370,8 @@ public final class WebSocketProvider: NetworkProvider {
                 }
                 try await Task.sleep(for: .seconds(waitBeforeReconnect))
                 // if endpoint is nil, this returns nil
-                if let newWebSocketTask = try await attemptConnect(to: endpoint) {
+                if try await attemptConnect(to: endpoint) {
                     reconnectAttempts += 1
-                    webSocketTask = newWebSocketTask
                     peered = true
                 } else {
                     webSocketTask = nil

--- a/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
+++ b/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
@@ -109,6 +109,9 @@ public final class WebSocketProvider: NetworkProvider {
     public func send(message: SyncV1Msg, to: PEER_ID?) async {
         guard let webSocketTask else {
             Logger.websocket.warning("WEBSOCKET: Attempt to send a message without a connection")
+            if config.logLevel.canTrace() {
+                Logger.websocket.trace("WEBSOCKET: - msg \(message.debugDescription) to peer \(String(describing: to))")
+            }
             return
         }
         var msgToSend = message


### PR DESCRIPTION
Adding more tracing in WebSocket, and fixing a logic flaw (event flow issue) where relevant mutable state was known but not correctly set in place when external events could be triggered - specifically, inital sync on connecting to a peer can trigger concurrently with finishing setup such that the send() can't operate since the connection state isn't finished setting up. Re-ordered that flow so that state _is_ set up completely before that signal is sent.

That signal _could_ be sent outside of the attemptConnect() flow, but two places can potentially call this logic flow, so keeping it together and (unfortunately - as a side effect) seemed like a better way to collapse the detail to be able to reason about it. I changed up the return value from attemptConnect() so that it's a bit "less" of a pure function, but it's (more) obvious that it operates on context/state and updates it (a mutable function)