### PR TITLE
illustrating hang in repo.find

### DIFF
--- a/IntegrationTests/Tests/IntegrationTestsTests/RepoWebsocketIntegrationTests.swift
+++ b/IntegrationTests/Tests/IntegrationTestsTests/RepoWebsocketIntegrationTests.swift
@@ -13,9 +13,9 @@ final class RepoWebsocketIntegrationTests: XCTestCase {
     private static let subsystem = Bundle.main.bundleIdentifier!
 
     static let test = Logger(subsystem: subsystem, category: "WebSocketSyncIntegrationTests")
-//    let syncDestination = "ws://localhost:3030/"
+    let syncDestination = "ws://localhost:3030/"
     // Switch to the following line to run a test against the public hosted automerge-repo instance
-    let syncDestination = "wss://sync.automerge.org/"
+//    let syncDestination = "wss://sync.automerge.org/"
 
     override func setUp() async throws {
         let isWebSocketConnectable = await webSocketAvailable(destination: syncDestination)

--- a/Tests/AutomergeRepoTests/RepoFindTest.swift
+++ b/Tests/AutomergeRepoTests/RepoFindTest.swift
@@ -1,0 +1,23 @@
+import Automerge
+@testable import AutomergeRepo
+import AutomergeUtilities
+import XCTest
+
+final class RepoFindTest: XCTestCase {
+    func testRepoFindWithoutNetworkingActive() async throws {
+        let repo = Repo(sharePolicy: SharePolicy.agreeable)
+        let websocket = WebSocketProvider(.init(reconnectOnError: false, loggingAt: .tracing))
+        await repo.addNetworkAdapter(adapter: websocket)
+
+        let unavailableExpectation = expectation(description: "find should throw an Unavailable error")
+        Task {
+            do {
+                let handle = try await repo.find(id: DocumentId()) // never completes, never errors
+                print(handle)
+            } catch {
+                unavailableExpectation.fulfill()
+            }
+        }
+        await fulfillment(of: [unavailableExpectation], timeout: 5)
+    }
+}

--- a/Tests/AutomergeRepoTests/RepoFindTest.swift
+++ b/Tests/AutomergeRepoTests/RepoFindTest.swift
@@ -5,11 +5,15 @@ import XCTest
 
 final class RepoFindTest: XCTestCase {
     func testRepoFindWithoutNetworkingActive() async throws {
+        // https://github.com/automerge/automerge-repo-swift/issues/84
         let repo = Repo(sharePolicy: SharePolicy.agreeable)
+        await repo.setLogLevel(.resolver, to: .tracing)
+        await repo.setLogLevel(.network, to: .tracing)
         let websocket = WebSocketProvider(.init(reconnectOnError: false, loggingAt: .tracing))
         await repo.addNetworkAdapter(adapter: websocket)
 
-        let unavailableExpectation = expectation(description: "find should throw an Unavailable error")
+        let unavailableExpectation =
+            expectation(description: "Find should throw an Unavailable error if no peers are available to request from")
         Task {
             do {
                 let handle = try await repo.find(id: DocumentId()) // never completes, never errors


### PR DESCRIPTION
Illustrates hang issue identified in #84, where requesting from peers will wait a full timeout of 300 seconds. Short circuiting the scenario where there aren't any peers to request from, and (more correctly) immediately reporting Unavailable.