### PR TITLE
terminate loop and attempt to reconnect if error reading websocket

### DIFF
--- a/Sources/AutomergeRepo/Errors.swift
+++ b/Sources/AutomergeRepo/Errors.swift
@@ -93,7 +93,7 @@ public enum Errors: Sendable {
             self.msg = msg
         }
     }
-    
+
     /// The ID of the document already exists within the repository
     public struct DuplicateID: Sendable, LocalizedError {
         public var id: DocumentId

--- a/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
+++ b/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
@@ -367,7 +367,7 @@ public final class WebSocketProvider: NetworkProvider {
 
             // if we're not currently peered, attempt to reconnect
             // (if we're configured to do so)
-            if !peered, config.reconnectOnError {
+            if !peered && config.reconnectOnError {
                 let waitBeforeReconnect = Backoff.delay(reconnectAttempts, withJitter: true)
                 if config.logLevel.canTrace() {
                     Logger.websocket
@@ -400,6 +400,10 @@ public final class WebSocketProvider: NetworkProvider {
                 Logger.websocket.warning("WEBSOCKET: Error reading websocket: \(error.localizedDescription)")
                 peered = false
                 webSocketTask.cancel()
+                if !config.reconnectOnError {
+                    // if we don't want to attempt to reconnect on error, terminate the retry loop
+                    break
+                }
                 try await Task.sleep(for: .seconds(1))
             }
 

--- a/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
+++ b/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
@@ -399,12 +399,12 @@ public final class WebSocketProvider: NetworkProvider {
                 // error scenario with the WebSocket connection
                 Logger.websocket.warning("WEBSOCKET: Error reading websocket: \(error.localizedDescription)")
                 peered = false
+                msgFromWebSocket = nil
                 webSocketTask.cancel()
                 if !config.reconnectOnError {
                     // if we don't want to attempt to reconnect on error, terminate the retry loop
                     break
                 }
-                try await Task.sleep(for: .seconds(1))
             }
 
             if let encodedMessage = msgFromWebSocket {

--- a/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
+++ b/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
@@ -404,21 +404,16 @@ public final class WebSocketProvider: NetworkProvider {
                 }
             }
 
-            guard let webSocketTask else {
-                Logger.websocket.warning("WEBSOCKET: Receive Handler: webSocketTask is nil, terminating handler loop")
-                break // terminates the while loop - no more reconnect attempts
-            }
-
             // co-operative cancellation
             if Task.isCancelled {
-                webSocketTask.cancel()
+                webSocketTask?.cancel()
                 peered = false
                 tryToReconnect = false
                 break
             }
 
             do {
-                msgFromWebSocket = try await webSocketTask.receive()
+                msgFromWebSocket = try await webSocketTask?.receive()
             } catch {
                 // error scenario with the WebSocket connection
                 Logger.websocket.warning("WEBSOCKET: Error reading websocket: \(error.localizedDescription)")

--- a/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
+++ b/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
@@ -398,6 +398,8 @@ public final class WebSocketProvider: NetworkProvider {
             } catch {
                 // error scenario with the WebSocket connection
                 Logger.websocket.warning("WEBSOCKET: Error reading websocket: \(error.localizedDescription)")
+                peered = false
+                webSocketTask.cancel()
             }
 
             if let encodedMessage = msgFromWebSocket {

--- a/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
+++ b/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
@@ -400,6 +400,7 @@ public final class WebSocketProvider: NetworkProvider {
                 Logger.websocket.warning("WEBSOCKET: Error reading websocket: \(error.localizedDescription)")
                 peered = false
                 webSocketTask.cancel()
+                try await Task.sleep(for: .seconds(1))
             }
 
             if let encodedMessage = msgFromWebSocket {

--- a/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
+++ b/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
@@ -390,13 +390,13 @@ public final class WebSocketProvider: NetworkProvider {
                             "WEBSOCKET: Reconnect attempt #\(reconnectAttempts), waiting for \(waitBeforeReconnect) seconds."
                         )
                 }
+                reconnectAttempts += 1
                 do {
                     try await Task.sleep(for: .seconds(waitBeforeReconnect))
                     // if endpoint is nil, this returns nil
-                    if try await attemptConnect(to: endpoint) {
-                        reconnectAttempts += 1
-                    } else {
+                    if !(try await attemptConnect(to: endpoint)) {
                         webSocketTask = nil
+                        peered = false
                     }
                 } catch {
                     webSocketTask = nil

--- a/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
+++ b/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
@@ -92,7 +92,16 @@ public final class WebSocketProvider: NetworkProvider {
         if ongoingReceiveMessageTask == nil {
             // infinitely loop and receive messages, but "out of band"
             ongoingReceiveMessageTask = Task.detached {
-                try await self.ongoingReceiveWebSocketMessages()
+                do {
+                    try await self.ongoingReceiveWebSocketMessages()
+                } catch {
+                    Logger.websocket.error("EXCEPTION from background receive loop: \(error.localizedDescription)")
+                }
+                if await self.config.logLevel.canTrace() {
+                    Logger.websocket.trace("Terminated background read loop - socket expected to be disconnected")
+                }
+                let peeredCopy = await self.peered
+                assert(peeredCopy == false)
             }
         }
     }


### PR DESCRIPTION
resolves (or changes) #83 

When wifi is unavailable, we get an error reading the websocket, but currently fail to terminate the loop and initiate a reconnect. This adds in the termination of the loop (peer=false, and attempts to cancel() the webSocket for good measure), which should force us into the backoff/retry loop