### PR TITLE
Find assert failure

### DIFF
--- a/Sources/AutomergeRepo/Errors.swift
+++ b/Sources/AutomergeRepo/Errors.swift
@@ -28,7 +28,7 @@ public enum Errors: Sendable {
 
     /// The document in unavailable.
     public struct Unavailable: Sendable, LocalizedError {
-        let id: DocumentId
+        public let id: DocumentId
         public var errorDescription: String? {
             "Unknown document Id: \(id)"
         }
@@ -40,7 +40,7 @@ public enum Errors: Sendable {
 
     /// The document is deleted.
     public struct DocDeleted: Sendable, LocalizedError {
-        let id: DocumentId
+        public let id: DocumentId
         public var errorDescription: String? {
             "Document with Id: \(id) has been deleted."
         }

--- a/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
+++ b/Sources/AutomergeRepo/Networking/Providers/WebSocketProvider.swift
@@ -50,7 +50,8 @@ public final class WebSocketProvider: NetworkProvider {
     ///
     /// The initial value provides the current state of the connecting in the WebSocket provider,
     /// with updates published when the state changes.
-    public nonisolated let statePublisher: CurrentValueSubject<WebSocketProviderState, Never> = CurrentValueSubject(.disconnected)
+    public nonisolated let statePublisher: CurrentValueSubject<WebSocketProviderState, Never> =
+        CurrentValueSubject(.disconnected)
 
     /// Creates a new instance of a WebSocket network provider with the configuration you provide.
     /// - Parameter config: The configuration for the provider.


### PR DESCRIPTION
resolves #92 

Don't merge until expected behavior is fully understood. I think this is falling for the "get an Unavailable message first, followed by a secondary message with data" that is resulting in a confused response, but I need to check that theory...