### PR TITLE
Add repo.load

### DIFF
--- a/Sources/AutomergeRepo/Repo.swift
+++ b/Sources/AutomergeRepo/Repo.swift
@@ -508,6 +508,29 @@ public final class Repo {
         let resolved = try await resolveDocHandle(id: handle.id)
         return resolved
     }
+    
+    public struct Bundle {
+        public let id: DocumentId
+        public let doc: Document
+    }
+    
+    /// Loads an external document/id pair into the repository.
+    ///
+    /// This implementation is very likely incorrect, but a start at sketching out what
+    /// a bundle loading might look like.
+    public func load(bundle: Bundle) async throws -> DocHandle {
+        if documentIds().contains(bundle.id) {
+            let handle = try await find(id: bundle.id)
+            try handle.doc.merge(other: bundle.doc)
+            return handle
+        } else {
+            let handle = InternalDocHandle(id: bundle.id, isNew: true, initialValue: bundle.doc)
+            handles[handle.id] = handle
+            docHandlePublisher.send(handle.snapshot())
+            let resolved = try await resolveDocHandle(id: handle.id)
+            return resolved
+        }
+    }
 
     /// Clones a document the repo already knows to create a new, shared document.
     /// - Parameter id: The id of the document to clone.

--- a/Sources/AutomergeRepo/Repo.swift
+++ b/Sources/AutomergeRepo/Repo.swift
@@ -522,7 +522,35 @@ public final class Repo {
     ///
     /// This implementation is very likely incorrect, but a start at sketching out what
     /// a bundle loading might look like.
+    ///
+    /// Load is an alternative to providing ID params to the create method. The thinking
+    /// is if you already have an ID then the document has already been created. And in
+    /// that case we want different sementics then create. If the ID is unknown to repo
+    /// then should have same behavior as create. But if the ID is known to repo then
+    /// should merge document states.
+    ///
+    /// Load should be used for cases where you have created a DocumentId/Document pair
+    /// outside of an automerge repo, and you want to load that pair into the repo. It
+    /// should also be used for case where you have stored a DocumentId/Document pair
+    /// external to a repo and you want to load that pair back into the repo.
+    ///
+    /// Expected Behavior:
+    /// - Quick, shouldn't wait on any network communication to complete
+    /// - If existing document with same ID is known to repo then this will merge bundle.doc with existing
+    /// - If deleted document with same ID is know to the repo then this method will replace that state with new document handle
+    /// - If repo don't know the ID then will behave like create
     public func load(bundle: Bundle) async throws -> DocHandle {
+        // Questions:
+        // I don't know how to handle existing handle states. For example what if load is
+        // called with a document id that already has an assocated handle in requesting
+        // state? The desired behavior woul be that repo gets bundle document immediatly
+        // and when request finishes that document state is merged into loaded document.
+        // I'm not sure if that even makes sense, or how to accomplish it.
+        //
+        // Same question for many of the various handle states. Again the general goal with
+        // load is that it will leave this repo in a state where loaded document is
+        // immediatly availible. Any pending action (load, request, maybe other stuff) on
+        // that ID should be incorported into loaded document.
         if documentIds().contains(bundle.id) {
             let handle = try await find(id: bundle.id)
             try handle.doc.merge(other: bundle.doc)

--- a/Sources/AutomergeRepo/Repo.swift
+++ b/Sources/AutomergeRepo/Repo.swift
@@ -512,6 +512,10 @@ public final class Repo {
     public struct Bundle {
         public let id: DocumentId
         public let doc: Document
+        public init(id: DocumentId, doc: Document) {
+            self.id = id
+            self.doc = doc
+        }
     }
     
     /// Loads an external document/id pair into the repository.


### PR DESCRIPTION
I'm not sure that it's the right design, but I'm playing with a bundle repo.load implementation to see what it looks like.

I think it could be used as a safer alternative to create(id). I also think it could be a way to reverse a repo.delete.

The general idea is a new repo operation that has create or update behavior. I think it could be a good fit for both loading external NSDocument stored data, and it also I "think" makes sense for reversing a delete.

Of course this pull isn't ready, but I figured I would make it so we could have some code to look and and place to attach discussion.