### PR TITLE
rename some of the repo API (half of `create`) to `import`

### DIFF
--- a/Tests/AutomergeRepoTests/BaseRepoTests.swift
+++ b/Tests/AutomergeRepoTests/BaseRepoTests.swift
@@ -38,16 +38,12 @@ final class BaseRepoTests: XCTestCase {
         XCTAssertEqual(knownIds[0], myId)
     }
 
-    func testCreateWithExistingDoc() async throws {
-        let handle = try await repo.create(doc: Document())
-        var knownIds = await repo.documentIds()
+    func testImportExistingDoc() async throws {
+        let newHandleWithDoc = DocHandle(id: DocumentId(), doc: Document())
+        let handle = try await repo.import(handle: newHandleWithDoc)
+        let knownIds = await repo.documentIds()
         XCTAssertEqual(knownIds.count, 1)
         XCTAssertEqual(knownIds[0], handle.id)
-
-        let myId = DocumentId()
-        let _ = try await repo.create(doc: Document(), id: myId)
-        knownIds = await repo.documentIds()
-        XCTAssertEqual(knownIds.count, 2)
     }
 
     func testFind() async throws {


### PR DESCRIPTION
renaming `create` to `import`, and accepting a DocHandle as the mechanism to provide an Automerge document with associated Id.

Semantics are merge-if-already-exists, replace if: unavailable, deleted, or non-existant in local repo. Attempt to store into persistence (using Storage Provider), if one is configured for the repository. This makes the generation of ID for a Automerge document consistent, and specifically in the control of the developer rather than inferring anything.

This picks up, potentially replaces, #96 
fixes #95 