### PR TITLE
fix build with Xcode 16 by disabling `InternalImportsByDefault`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,9 @@ let package = Package(
                 .enableExperimentalFeature("StrictConcurrency"),
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableExperimentalFeature("AccessLevelOnImport"),
-                .enableUpcomingFeature("InternalImportsByDefault"),
+                // TODO: re-enable this and fix imports (aka add lots of `public import`)
+                // when building with Xcode 16
+                // .enableUpcomingFeature("InternalImportsByDefault"),
             ]
         ),
         .testTarget(


### PR DESCRIPTION
`InternalImportsByDefault` makes all imports `internal` by default. This means that none of those imports can be used in public interfaces. 
Currently this repo _is_ using lots of `internal imports` and it seems like the feature is ignored in Xcode 15. Building on Xcode 16 breaks as expected.

I'm not 100% clear on how the transition to this feature will work, and if the feature can only be enabled once everyone's building with Xcode 16?

Disabling the feature now and adding a comment to make builds work with Xcode 16 (beta 3)