### PR TITLE
allow setting the logVerbosity of Documents created within the repo

### DIFF
--- a/Sources/AutomergeRepo/Repo.swift
+++ b/Sources/AutomergeRepo/Repo.swift
@@ -24,7 +24,11 @@ public final class Repo {
     let defaultVerbosity: LogVerbosity = .errorOnly
     private var levels: [LogComponent: LogVerbosity] = [:]
     /// LogVerbosity of Documents created from the Repo
-    public var documentLogVerbosity: LogVerbosity = .errorOnly
+    public var documentLogVerbosity: LogVerbosity = .errorOnly {
+        didSet {
+            self.storage?.documentLogLevel = documentLogVerbosity
+        }
+    }
 
     // MARK: log filtering
 
@@ -161,7 +165,7 @@ public final class Repo {
         pendingRequestWaitDuration = resolveFetchIterationDelay
         self.sharePolicy = sharePolicy as any ShareAuthorizing
         network = NetworkSubsystem(verbosity: .errorOnly)
-        self.storage = DocumentStorage(storage, verbosity: .errorOnly)
+        self.storage = DocumentStorage(storage, verbosity: .errorOnly, documentLogVerbosity: documentLogVerbosity)
         localPeerMetadata = PeerMetadata(storageId: storage.id, isEphemeral: false)
         saveDebounceDelay = saveDebounce
         Task { await self.setupSaveHandler() }
@@ -191,7 +195,7 @@ public final class Repo {
         peerId = UUID().uuidString
         maxRetriesForFetch = maxResolveFetchIterations
         pendingRequestWaitDuration = resolveFetchIterationDelay
-        self.storage = DocumentStorage(storage, verbosity: .errorOnly)
+        self.storage = DocumentStorage(storage, verbosity: .errorOnly, documentLogVerbosity: documentLogVerbosity)
         self.saveDebounceDelay = saveDebounce
 
         localPeerMetadata = PeerMetadata(storageId: storage.id, isEphemeral: false)

--- a/Sources/AutomergeRepo/Storage/DocumentStorage.swift
+++ b/Sources/AutomergeRepo/Storage/DocumentStorage.swift
@@ -20,10 +20,11 @@ final class DocumentStorage {
     var chunks: [DocumentId: [Data]]
 
     var loglevel: LogVerbosity
+    var documentLogLevel: LogVerbosity
 
     /// Creates a new concurrency safe document storage instance to manage changes to Automerge documents.
     /// - Parameter storage: The storage provider
-    public nonisolated init(_ storage: some StorageProvider, verbosity: LogVerbosity) {
+    public nonisolated init(_ storage: some StorageProvider, verbosity: LogVerbosity, documentLogVerbosity: LogVerbosity) {
         compacting = false
         _storage = storage
         latestHeads = [:]
@@ -36,6 +37,7 @@ final class DocumentStorage {
         memoryChunkSize = [:]
         storedDocSize = [:]
         self.loglevel = verbosity
+        self.documentLogLevel = documentLogVerbosity
     }
 
     func setLogVerbosity(_ level: LogVerbosity) {
@@ -95,7 +97,7 @@ final class DocumentStorage {
             combined.append(chunk)
         }
         storedChunkSize[id] = storedChunks
-        let combinedDoc = try Document(combined)
+        let combinedDoc = try Document(combined, logLevel: documentLogLevel)
         latestHeads[id] = combinedDoc.heads()
 
         return combinedDoc
@@ -189,7 +191,7 @@ final class DocumentStorage {
             combined.append(chunk)
         }
 
-        let compactedDoc = try Document(combined)
+        let compactedDoc = try Document(combined, logLevel: documentLogLevel)
 
         let compactedData = compactedDoc.save()
         // only remove the chunks AFTER the save is complete

--- a/Sources/AutomergeRepo/Storage/DocumentStorage.swift
+++ b/Sources/AutomergeRepo/Storage/DocumentStorage.swift
@@ -24,7 +24,7 @@ final class DocumentStorage {
 
     /// Creates a new concurrency safe document storage instance to manage changes to Automerge documents.
     /// - Parameter storage: The storage provider
-    public nonisolated init(_ storage: some StorageProvider, verbosity: LogVerbosity, documentLogVerbosity: LogVerbosity) {
+    public nonisolated init(_ storage: some StorageProvider, verbosity: LogVerbosity, documentLogVerbosity: LogVerbosity = .errorOnly) {
         compacting = false
         _storage = storage
         latestHeads = [:]

--- a/Tests/AutomergeRepoTests/StorageSubsystemTests.swift
+++ b/Tests/AutomergeRepoTests/StorageSubsystemTests.swift
@@ -14,7 +14,7 @@ final class StorageSubsystemTests: XCTestCase {
         XCTAssertEqual(docIds.count, 0)
         XCTAssertEqual(incrementalKeys.count, 0)
 
-        subsystem = DocumentStorage(storageProvider, verbosity: .tracing)
+        subsystem = DocumentStorage(storageProvider, verbosity: .tracing, documentLogVerbosity: .tracing)
         testStorageProvider = storageProvider
     }
 


### PR DESCRIPTION
`LogVerbosity` on automerge's `Document` is internal and can only be specified on document creation.
This PR allows setting the default for this via the repository.

Note: My first approach was to add a case in `LogComponent`, though that _also_ needs a logger. Given we don't really want to log into the `Document`'s logger from the `Repo`, it felt better to add a separate public variable. Happy to adjust though!